### PR TITLE
feat: add invalid routes and error page

### DIFF
--- a/src/content/components/ActiveRSMessages/ActiveRSMessages.tsx
+++ b/src/content/components/ActiveRSMessages/ActiveRSMessages.tsx
@@ -3,6 +3,8 @@ import { getTargetingAttributes } from "./TargetingParser";
 import styles from "./ActiveRSMessages.scss";
 import { columnTransforms } from "../BugList/columnTransforms";
 import { fetchBugById, RSMessage } from "../../../server/queryUtils";
+import ReactDOM from "react-dom";
+import { ErrorView } from "../ErrorView/ErrorView";
 
 interface CFRMessage extends RSMessage {
   content: {
@@ -149,7 +151,17 @@ export class ActiveRSMessages extends React.PureComponent {
       })
       .then(messages =>
         this.setState({ messages, selectedBucket: BUCKETS[bkey] })
-      );
+      )
+      .catch(() => {
+        ReactDOM.render(
+          <ErrorView
+            header={"Error"}
+            subheader={"There was an error fetching data."}
+            buttonText={"Try again"}
+          />,
+          document.getElementById("root")
+        );
+      });
   }
 
   bucketUpdate(el: React.ChangeEvent<HTMLSelectElement>) {

--- a/src/content/components/ErrorView/ErrorView.tsx
+++ b/src/content/components/ErrorView/ErrorView.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import gStyles from "../../styles/gStyles.scss";
+
+type ErrorViewProps = {
+  header: string;
+  subheader: string;
+  buttonText: string;
+  buttonHref?: string;
+};
+
+const containerStyle = {
+  maxWidth: 900,
+  margin: "0 auto",
+  padding: "20px 40px",
+  textAlign: "center",
+};
+
+const refreshPage = () => {
+  window.location.reload();
+};
+
+export class ErrorView extends React.PureComponent<ErrorViewProps> {
+  render() {
+    return (
+      <div style={containerStyle}>
+        <h1>{this.props.header}</h1>
+        <p>{this.props.subheader}</p>
+        <a
+          className={gStyles.primaryButton}
+          onClick={!this.props.buttonHref ? refreshPage : null}
+          href={this.props.buttonHref || ""}>
+          {this.props.buttonText}
+        </a>
+      </div>
+    );
+  }
+}

--- a/src/content/components/ErrorView/ErrorView.tsx
+++ b/src/content/components/ErrorView/ErrorView.tsx
@@ -12,7 +12,7 @@ const containerStyle = {
   maxWidth: 900,
   margin: "0 auto",
   padding: "20px 40px",
-  textAlign: "center",
+  textAlign: "center" as const,
 };
 
 const refreshPage = () => {

--- a/src/content/components/Preferences/Preferences.js
+++ b/src/content/components/Preferences/Preferences.js
@@ -1,0 +1,110 @@
+import React from "react";
+import styles from "./Preferences.scss";
+import { prefs } from "../../lib/prefs";
+import ReactDOM from "react-dom";
+import { ErrorView } from "../ErrorView/ErrorView";
+
+export class Preferences extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      bugzilla_email: prefs.get("bugzilla_email"),
+      offline_debug: prefs.get("offline_debug"),
+    };
+    this.onInputChange = this.onInputChange.bind(this);
+    this.onCheckBoxChange = this.onCheckBoxChange.bind(this);
+  }
+
+  onInputChange(e) {
+    const newState = {};
+    newState[e.target.name] = e.target.value;
+    this.setState(newState);
+    prefs.set(e.target.name, e.target.value);
+  }
+
+  onCheckBoxChange(e) {
+    const newState = {};
+    newState[e.target.name] = e.target.checked;
+    this.setState(newState);
+    prefs.set(e.target.name, e.target.checked);
+  }
+
+  // A button for testing iterations
+  onIterationsCheck() {
+    fetch()
+      .then(rsp => rsp.json())
+      .catch(
+        ReactDOM.render(
+          <ErrorView
+            header={"Error"}
+            subheader={"There was an error fetching data."}
+            buttonText={"Try again"}
+          />,
+          document.getElementById("root")
+        )
+      );
+  }
+
+  render() {
+    return (
+      <div className={styles.container}>
+        <h1>About</h1>
+        <p>
+          Please file issues at{" "}
+          <a href="https://github.com/mozilla/bugzy/issues/new/choose">
+            github.com/mozilla/bugzy
+          </a>
+        </p>
+        {/* <table className={styles.table}>
+          <tbody>
+            <tr>
+              <td>
+                <label htmlFor="bugzilla_email">Bugzilla Email</label>
+              </td>
+              <td>
+                <input
+                  name="bugzilla_email"
+                  type="email"
+                  onChange={this.onInputChange}
+                  value={this.state.bugzilla_email}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <label htmlFor="offline_debug">
+                  Debug in offline mode (fake data)
+                </label>
+              </td>
+              <td>
+                <input
+                  type="checkbox"
+                  name="offline_debug"
+                  onChange={this.onCheckBoxChange}
+                  checked={this.state.offline_debug}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <button
+                  name="iterations_check"
+                  onClick={this.onIterationsCheck}>
+                  Check iterations (logged in console)
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table> */}
+
+        <h3>Credits</h3>
+        <p>
+          Icons are designed by <a href="https://smashicons.com/">Smashicons</a>
+          , <a href="https://www.freepik.com/">Freepik</a>, and{" "}
+          <a href="https://roundicons.com/">Roundicons</a> from{" "}
+          <a href="https://www.flaticon.com">flaticon.com</a>
+        </p>
+      </div>
+    );
+  }
+}

--- a/src/content/components/Preferences/Preferences.js
+++ b/src/content/components/Preferences/Preferences.js
@@ -13,20 +13,25 @@ export class Preferences extends React.PureComponent {
     };
     this.onInputChange = this.onInputChange.bind(this);
     this.onCheckBoxChange = this.onCheckBoxChange.bind(this);
+    this.onPrefChange = this.onPrefChange.bind(this);
+
+    for (const pref of ["bugzilla_email", "offline_debug"]) {
+      prefs.on(pref, this.onPrefChange);
+    }
   }
 
   onInputChange(e) {
-    const newState = {};
-    newState[e.target.name] = e.target.value;
-    this.setState(newState);
     prefs.set(e.target.name, e.target.value);
   }
 
   onCheckBoxChange(e) {
-    const newState = {};
-    newState[e.target.name] = e.target.checked;
-    this.setState(newState);
     prefs.set(e.target.name, e.target.checked);
+  }
+
+  onPrefChange({ name, newValue } = {}) {
+    const newState = {};
+    newState[name] = newValue;
+    this.setState(newState);
   }
 
   // A button for testing iterations
@@ -45,6 +50,13 @@ export class Preferences extends React.PureComponent {
       );
   }
 
+  componentWillMount() {
+    this.state = {
+      bugzilla_email: prefs.get("bugzilla_email"),
+      offline_debug: prefs.get("offline_debug"),
+    };
+  }
+
   render() {
     return (
       <div className={styles.container}>
@@ -55,47 +67,47 @@ export class Preferences extends React.PureComponent {
             github.com/mozilla/bugzy
           </a>
         </p>
-        {/* <table className={styles.table}>
-          <tbody>
-            <tr>
-              <td>
+        {process.env.NODE_ENV === "production" ? null : (
+          <div id="prefs" className={styles.list}>
+            <div className={styles.row}>
+              <div className={styles.col}>
                 <label htmlFor="bugzilla_email">Bugzilla Email</label>
-              </td>
-              <td>
+              </div>
+              <div className={styles.col}>
                 <input
                   name="bugzilla_email"
                   type="email"
                   onChange={this.onInputChange}
                   value={this.state.bugzilla_email}
                 />
-              </td>
-            </tr>
-            <tr>
-              <td>
+              </div>
+            </div>
+            <div className={styles.row}>
+              <div className={styles.col}>
                 <label htmlFor="offline_debug">
                   Debug in offline mode (fake data)
                 </label>
-              </td>
-              <td>
+              </div>
+              <div className={styles.col}>
                 <input
                   type="checkbox"
                   name="offline_debug"
                   onChange={this.onCheckBoxChange}
                   checked={this.state.offline_debug}
                 />
-              </td>
-            </tr>
-            <tr>
-              <td>
+              </div>
+            </div>
+            <div className={styles.row}>
+              <div className={styles.col}>
                 <button
                   name="iterations_check"
                   onClick={this.onIterationsCheck}>
                   Check iterations (logged in console)
                 </button>
-              </td>
-            </tr>
-          </tbody>
-        </table> */}
+              </div>
+            </div>
+          </div>
+        )}
 
         <h3>Credits</h3>
         <p>

--- a/src/content/components/Router/Router.js
+++ b/src/content/components/Router/Router.js
@@ -28,6 +28,7 @@ import { BUGZILLA_TRIAGE_COMPONENTS } from "../../../config/project_settings";
 import { isBugResolved } from "../../lib/utils";
 import { UnassignedView } from "../UnassignedView/UnassignedView";
 import { SettingsView } from "../SettingsView/SettingsView";
+import { ErrorView } from "../ErrorView/ErrorView";
 
 function nimbusSort(a, b) {
   const aPriortity = a.priority === "--" ? "PX" : a.priority;
@@ -500,7 +501,21 @@ export class Router extends React.PureComponent {
           component: AboutView,
         },
       },
-    ]
+      {
+        hide: true,
+        routeProps: {
+          path: "*",
+          render: () => (
+            <ErrorView
+              header={"Invalid Route"}
+              subheader={"The page you were looking for was not found."}
+              buttonText={"Current Iteration"}
+              buttonHref={"/current_iteration"}
+            />
+          ),
+        },
+      },
+    ];
 
     return (
       <BrowserRouter>

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -4,20 +4,35 @@ import { GlobalContextProvider } from "./components/GlobalContext/GlobalContext"
 import { Iterations } from "../common/IterationLookup";
 import { QueryManager } from "./lib/utils";
 import { Router } from "./components/Router/Router";
+import { ErrorView } from "./components/ErrorView/ErrorView";
 
 async function main() {
-  const [metas, iterationsLookup] = await Promise.all([
-    fetch("/api/metas").then(res => res.json()),
-    fetch("/api/iterations").then(res => res.json()),
-  ]);
-  const iterations = new Iterations(iterationsLookup);
-  const qm = makeQueryManager(iterations);
-  ReactDOM.render(
-    <GlobalContextProvider metas={metas} iterations={iterations} qm={qm}>
-      <Router />
-    </GlobalContextProvider>,
-    document.getElementById("root")
-  );
+  try {
+    const [metas, iterationsLookup] = await Promise.all([
+      fetch("/api/metas").then(res => res.json()),
+      fetch("/api/iterations").then(res => res.json()),
+    ]);
+
+    if (metas && iterationsLookup) {
+      const iterations = new Iterations(iterationsLookup);
+      const qm = makeQueryManager(iterations);
+      ReactDOM.render(
+        <GlobalContextProvider metas={metas} iterations={iterations} qm={qm}>
+          <Router />
+        </GlobalContextProvider>,
+        document.getElementById("root")
+      );
+    }
+  } catch (err) {
+    ReactDOM.render(
+      <ErrorView
+        header={"Error"}
+        subheader={"There was an error fetching data."}
+        buttonText={"Try again"}
+      />,
+      document.getElementById("root")
+    );
+  }
 }
 
 function makeQueryManager(iterations: Iterations) {

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -12,17 +12,18 @@ async function main() {
       fetch("/api/metas").then(res => res.json()),
       fetch("/api/iterations").then(res => res.json()),
     ]);
-
-    if (metas && iterationsLookup) {
-      const iterations = new Iterations(iterationsLookup);
-      const qm = makeQueryManager(iterations);
-      ReactDOM.render(
-        <GlobalContextProvider metas={metas} iterations={iterations} qm={qm}>
-          <Router />
-        </GlobalContextProvider>,
-        document.getElementById("root")
-      );
+    if (!metas || !iterationsLookup) {
+      throw null;
     }
+
+    const iterations = new Iterations(iterationsLookup);
+    const qm = makeQueryManager(iterations);
+    ReactDOM.render(
+      <GlobalContextProvider metas={metas} iterations={iterations} qm={qm}>
+        <Router />
+      </GlobalContextProvider>,
+      document.getElementById("root")
+    );
   } catch (err) {
     ReactDOM.render(
       <ErrorView


### PR DESCRIPTION
To test the invalid routes page, navigate to any nonexistent route:
<img width="1432" alt="image" src="https://user-images.githubusercontent.com/17807246/224171639-e2c68a1b-4150-46b6-a382-9a046ce210f9.png">


To test the error page, turn off your internet and load Bugzy, or replace `fetch("/api/metas")` or `fetch("/api/metas")` on lines 11 and 16 in `src/content/index.tsx` with an invalid URL:
<img width="1427" alt="image" src="https://user-images.githubusercontent.com/17807246/224172048-f535e75d-e795-49f3-b32e-03f9fffe3efa.png">


Closes #218.