### PR TITLE
Add the useless but charming "cosmic rays" tag

### DIFF
--- a/src/config/tags.js
+++ b/src/config/tags.js
@@ -60,7 +60,7 @@ module.exports = {
   "strings m-c needed": {
     label: "strings m-c needed",
     style: {
-      backgroundColor: "var(--teal-80",
+      backgroundColor: "var(--teal-80)",
       color: "white",
       border: 0,
       fontWeight: "bold",
@@ -70,6 +70,15 @@ module.exports = {
     label: "chore",
     style: {
       backgroundColor: "var(--purple-60)",
+      color: "white",
+      border: 0,
+      fontWeight: "bold",
+    },
+  },
+  "cosmic rays": {
+    label: "☄️ cosmic rays",
+    style: {
+      backgroundColor: "var(--magenta-80)",
       color: "white",
       border: 0,
       fontWeight: "bold",


### PR DESCRIPTION
Dan's mention of the possible effects of cosmic rays during our retro was so delightful that I felt the need to add a tag we could use, on any weird telemetry bugs or intermittents we can’t explain. Because joy, and no other reason.

Appears when the [cosmic rays] whiteboard tag is used on Bugzilla.