### PR TITLE
Issue 301 - Increase contrast between P1 and P2 labels

### DIFF
--- a/src/content/components/PriorityGuide/PriorityGuide.module.scss
+++ b/src/content/components/PriorityGuide/PriorityGuide.module.scss
@@ -37,17 +37,17 @@
 }
 
 .p1 {
-  background: #45a1ff;
+  background: #45A1FF;
   border-color: transparent;
   color: white;
 }
 .p2 {
-  background: #9fc6ee;
+  background: #9FC6EE;
   border-color: transparent;
   color: white;
 }
 .p3 {
-  color: #45a1ff;
+  color: #45A1FF;
   background: transparent;
 }
 .p4, .p5 {

--- a/src/content/components/PriorityGuide/PriorityGuide.module.scss
+++ b/src/content/components/PriorityGuide/PriorityGuide.module.scss
@@ -37,17 +37,17 @@
 }
 
 .p1 {
-  background: #45A1FF;
+  background: #0083ff;
   border-color: transparent;
   color: white;
 }
 .p2 {
-  background: #9FC6EE;
+  background: #ac6bc3;
   border-color: transparent;
   color: white;
 }
 .p3 {
-  color: #45A1FF;
+  color: #bf6fd4;
   background: transparent;
 }
 .p4, .p5 {


### PR DESCRIPTION
Fixes https://github.com/mozilla/bugzy/issues/301

These are the screenshots showing the new colors chosen for the priority labels. The colors have been adjusted to work in both light and dark mode (using dark reader).

<img width="216" alt="Screenshot 2024-05-06 at 10 16 07 AM" src="https://github.com/mozilla/bugzy/assets/60327675/bdddd410-23c8-436e-9e2a-c2090554f080">
<img width="223" alt="Screenshot 2024-05-06 at 10 15 55 AM" src="https://github.com/mozilla/bugzy/assets/60327675/0908f1aa-2f61-4b46-833a-e04b7b38306d">

